### PR TITLE
Add xdebug to php image

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -117,6 +117,8 @@ RUN . /usr/src/config && \
         mv /usr/local/php/lib/php/extensions/no-debug-non-zts-[0-9]*/* /usr/local/php/lib/php/extensions && \
         #  Install, including pecl_http (dependencies satisfied at this point)
         yes '' | pecl install -n pecl_http-3.2.3; \
+        #  Install, including xdebug (dependencies satisfied at this point)
+        yes '' | pecl install -n xdebug; \
         mv /usr/local/php/lib/php/extensions/no-debug-non-zts-[0-9]*/* /usr/local/php/lib/php/extensions && \
         # Configure php-fpm to use an existant user
         sed -i'' -e 's/^group = nobody/group = nogroup/' /usr/local/php/etc/php-fpm.d/www.conf.default && \


### PR DESCRIPTION
Add xdebug php extension to the php image.

No config included and the extension is disabled by default.