### PR TITLE
Update Percona to 5.7

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM percona:5.6.41
+FROM percona:5.7.31
 
 # NOTE: This is not a production build: for sandbox/CI use only
 


### PR DESCRIPTION
Acquia recently updated their version of Percona from 5.6 to 5.7 so this update keeps us aligned.